### PR TITLE
Feature/blitz init workspace/save workspace details in db

### DIFF
--- a/blitzkrieg/db/models/environment_variable.py
+++ b/blitzkrieg/db/models/environment_variable.py
@@ -1,0 +1,15 @@
+from sqlalchemy import UUID, Column, ForeignKey, Integer, String
+from sqlalchemy.orm import relationship
+
+from blitzkrieg.db.models.base import Base
+
+class EnvironmentVariable(Base):
+    __tablename__ = 'environment_variable'
+    __table_args__ = {'schema': 'project_management'}
+
+    id = Column(Integer, primary_key=True)
+    name = Column(String)
+    value = Column(String)
+    workspace_id = Column(UUID, ForeignKey('project_management.workspace.id'))
+
+    workspace = relationship('Workspace')

--- a/blitzkrieg/db/models/environment_variable.py
+++ b/blitzkrieg/db/models/environment_variable.py
@@ -7,7 +7,7 @@ class EnvironmentVariable(Base):
     __tablename__ = 'environment_variable'
     __table_args__ = {'schema': 'project_management'}
 
-    id = Column(Integer, primary_key=True)
+    id = Column(UUID, primary_key=True)
     name = Column(String)
     value = Column(String)
     workspace_id = Column(UUID, ForeignKey('project_management.workspace.id'))

--- a/blitzkrieg/db/models/workspace.py
+++ b/blitzkrieg/db/models/workspace.py
@@ -1,0 +1,25 @@
+from sqlalchemy import UUID, Column, ForeignKey, String
+from sqlalchemy.orm import relationship
+from blitzkrieg.db.models.base import Base
+
+
+class Workspace(Base):
+    __tablename__ = 'workspace'
+    __table_args__ = {'schema': 'project_management'}
+
+    id = Column(UUID, primary_key=True)
+    name = Column(String)
+    pgadmin_port = Column(String)
+    pgadmin_username = Column(String)
+    pgadmin_password = Column(String)
+    postgres_port = Column(String)
+    postgres_username = Column(String)
+    postgres_host = Column(String)
+    postgres_db = Column(String)
+    postgres_password = Column(String)
+    description = Column(String)
+    project_id = Column(UUID, ForeignKey('project_management.project.id'))
+    path = Column(String)
+    sqlalchemy_uri = Column(String)
+
+    project = relationship('Project')

--- a/blitzkrieg/db/models/workspace.py
+++ b/blitzkrieg/db/models/workspace.py
@@ -1,6 +1,8 @@
-from sqlalchemy import UUID, Column, ForeignKey, String
+from sqlalchemy import Column, ForeignKey, String
 from sqlalchemy.orm import relationship
 from blitzkrieg.db.models.base import Base
+
+from sqlalchemy.dialects.postgresql import UUID
 
 
 class Workspace(Base):

--- a/blitzkrieg/db/models/workspace.py
+++ b/blitzkrieg/db/models/workspace.py
@@ -9,17 +9,5 @@ class Workspace(Base):
 
     id = Column(UUID, primary_key=True)
     name = Column(String)
-    pgadmin_port = Column(String)
-    pgadmin_username = Column(String)
-    pgadmin_password = Column(String)
-    postgres_port = Column(String)
-    postgres_username = Column(String)
-    postgres_host = Column(String)
-    postgres_db = Column(String)
-    postgres_password = Column(String)
     description = Column(String)
-    project_id = Column(UUID, ForeignKey('project_management.project.id'))
     path = Column(String)
-    sqlalchemy_uri = Column(String)
-
-    project = relationship('Project')

--- a/blitzkrieg/file_writers/workspace_docker_compose_writer.py
+++ b/blitzkrieg/file_writers/workspace_docker_compose_writer.py
@@ -29,6 +29,7 @@ class WorkspaceDockerComposeWriter(BaseDockerComposeWriter):
                     'POSTGRES_USER': f"{self.workspace_name}-db-user",
                     'POSTGRES_PASSWORD': 'pw'
                 },
+                'ports': ['5432:5432'],
                 'volumes': ['postgres_data:/var/lib/postgresql/data'],
                 'networks': [self.network_name],
                 'healthcheck': {

--- a/blitzkrieg/file_writers/workspace_docker_compose_writer.py
+++ b/blitzkrieg/file_writers/workspace_docker_compose_writer.py
@@ -1,9 +1,11 @@
 from blitzkrieg.file_writers.base_docker_compose_writer import BaseDockerComposeWriter
 from blitzkrieg.pgadmin_manager import PgAdminManager
+from blitzkrieg.postgres_manager import WorkspaceDbManager
 from blitzkrieg.ui_management.ConsoleInterface import ConsoleInterface
+from blitzkrieg.utils.port_allocation import find_available_port
 
 class WorkspaceDockerComposeWriter(BaseDockerComposeWriter):
-    def __init__(self, workspace_name: str, workspace_path: str, console: ConsoleInterface, pgadmin_manager: PgAdminManager):
+    def __init__(self, workspace_name: str, workspace_path: str, console: ConsoleInterface, pgadmin_manager: PgAdminManager, postgres_manager: WorkspaceDbManager):
         super().__init__(console=console, path=workspace_path)
         self.workspace_name = workspace_name
         self.network_name = f"{self.workspace_name}-network"
@@ -13,6 +15,7 @@ class WorkspaceDockerComposeWriter(BaseDockerComposeWriter):
         }
         self.console = console
         self.pgadmin = pgadmin_manager
+        self.postgres: WorkspaceDbManager = postgres_manager
         self.initialize_services()
 
     def add_service(self, name: str, service_config: dict):
@@ -29,7 +32,7 @@ class WorkspaceDockerComposeWriter(BaseDockerComposeWriter):
                     'POSTGRES_USER': f"{self.workspace_name}-db-user",
                     'POSTGRES_PASSWORD': 'pw'
                 },
-                'ports': ['5432:5432'],
+                'ports': [f"{self.postgres.db_port}: {self.postgres.db_port}"],
                 'volumes': ['postgres_data:/var/lib/postgresql/data'],
                 'networks': [self.network_name],
                 'healthcheck': {
@@ -55,7 +58,7 @@ class WorkspaceDockerComposeWriter(BaseDockerComposeWriter):
                 ],
                 'networks': [self.network_name],
                 'ports': [
-                    f"{self.pgadmin.pgadmin_port}:{self.pgadmin.pgadmin_port}",
+                    f"{self.pgadmin.pgadmin_port}:80",
                     f"{self.pgadmin.pgadmin_port_2}:{self.pgadmin.pgadmin_port_2}"]
             }
         )

--- a/blitzkrieg/file_writers/workspace_docker_compose_writer.py
+++ b/blitzkrieg/file_writers/workspace_docker_compose_writer.py
@@ -32,7 +32,7 @@ class WorkspaceDockerComposeWriter(BaseDockerComposeWriter):
                     'POSTGRES_USER': f"{self.workspace_name}-db-user",
                     'POSTGRES_PASSWORD': 'pw'
                 },
-                'ports': [f"{self.postgres.db_port}: {self.postgres.db_port}"],
+                'ports': [f"{self.postgres.db_port}:{self.postgres.db_port}"],
                 'volumes': ['postgres_data:/var/lib/postgresql/data'],
                 'networks': [self.network_name],
                 'healthcheck': {

--- a/blitzkrieg/postgres_manager.py
+++ b/blitzkrieg/postgres_manager.py
@@ -29,11 +29,17 @@ class WorkspaceDbManager:
         self.image_name = "postgres:latest"
         self.console_interface = console if console else ConsoleInterface()
         self.docker_manager = DockerManager(console=self.console_interface)
+        self.connection = None
+
+    def set_connection(self):
+        engine = sqlalchemy.create_engine(self.get_sqlalchemy_uri())
+        self.connection = engine.connect()
 
 
     def initialize(self):
         self.run_postgres_container()
         self.check_postgres_password()
+
 
     def test_sqlalchemy_postgres_connection(self):
             # Replace with your actual connection string

--- a/blitzkrieg/workspace_manager.py
+++ b/blitzkrieg/workspace_manager.py
@@ -48,6 +48,7 @@ class WorkspaceManager:
             console_interface=self.console,
             docker_manager=self.docker_manager
         )
+        self.workspace_db_manager.set_workspace_directory_manager(self.workspace_directory_manager)
         self.docker_network_name: str = f"{self.workspace_name}-network"
         self.cwd = os.getcwd()
         self.alembic_manager: AlembicManager = AlembicManager(
@@ -56,8 +57,10 @@ class WorkspaceManager:
             file_manager=self.file_manager,
             console=self.console
         )
+        self.workspace_db_manager.set_alembic_manager(self.alembic_manager)
+        self.workspace_db_manager.set_pgadmin_manager(self.pgadmin_manager)
         self.workspace_dockerfile_writer = WorkspaceDockerfileWriter(workspace_path=self.workspace_directory_manager.workspace_path, console=self.console)
-        self.workspace_docker_compose_writer = WorkspaceDockerComposeWriter(workspace_name=self.workspace_name, workspace_path=self.workspace_directory_manager.workspace_path, console=self.console, pgadmin_manager=self.pgadmin_manager)
+        self.workspace_docker_compose_writer = WorkspaceDockerComposeWriter(workspace_name=self.workspace_name, workspace_path=self.workspace_directory_manager.workspace_path, console=self.console, pgadmin_manager=self.pgadmin_manager, postgres_manager=self.workspace_db_manager)
         self.file_manager = FileManager()
 
     def blitz_init(self):

--- a/blitzkrieg/workspace_manager.py
+++ b/blitzkrieg/workspace_manager.py
@@ -19,14 +19,14 @@ from prettytable import PrettyTable
 
 class WorkspaceManager:
     def __init__(self, workspace_name, console: ConsoleInterface = None, email=None, password=None):
-        self.email = email
-        self.password = password
-        self.workspace_name = workspace_name
-        self.console = console if console else ConsoleInterface()
-        self.docker_manager = DockerManager(console=self.console)
-        self.postgres_port = find_available_port(5432)
-        self.pgadmin_port = find_available_port(5050)
-        self.pgadmin_manager = PgAdminManager(
+        self.email: str = email
+        self.password: str = password
+        self.workspace_name: str = workspace_name
+        self.console: ConsoleInterface = console if console else ConsoleInterface()
+        self.docker_manager: DockerManager = DockerManager(console=self.console)
+        self.postgres_port: int = find_available_port(5432)
+        self.pgadmin_port: int = find_available_port(5050)
+        self.pgadmin_manager:PgAdminManager = PgAdminManager(
             postgres_port=self.postgres_port,
             pgadmin_port=self.pgadmin_port,
             workspace_name=self.workspace_name,
@@ -34,30 +34,28 @@ class WorkspaceManager:
             email=email,
             password=password
         )
-        self.file_manager = FileManager()
-        self.workspace_db_manager = WorkspaceDbManager(
+        self.file_manager: FileManager = FileManager()
+        self.workspace_db_manager: WorkspaceDbManager = WorkspaceDbManager(
             port=self.postgres_port,
             workspace_name=self.workspace_name,
             console=self.console,
             email=email,
             password=password
         )
-        self.workspace_directory_manager = WorkspaceDirectoryManager(
+        self.workspace_directory_manager: WorkspaceDirectoryManager = WorkspaceDirectoryManager(
             workspace_name=self.workspace_name,
             db_manager=self.workspace_db_manager,
             console_interface=self.console,
             docker_manager=self.docker_manager
         )
-        self.docker_network_name = f"{self.workspace_name}-network"
+        self.docker_network_name: str = f"{self.workspace_name}-network"
         self.cwd = os.getcwd()
-        self.alembic_manager = AlembicManager(
+        self.alembic_manager: AlembicManager = AlembicManager(
             db_manager=self.workspace_db_manager,
             workspace_name=self.workspace_name,
             file_manager=self.file_manager,
             console=self.console
         )
-        self.dockerfile_manager = DockerfileManager(workspace_name=self.workspace_name, console=self.console)
-        self.docker_compose_manager = DockerComposeManager(console=self.console, workspace_name=self.workspace_name)
         self.workspace_dockerfile_writer = WorkspaceDockerfileWriter(workspace_path=self.workspace_directory_manager.workspace_path, console=self.console)
         self.workspace_docker_compose_writer = WorkspaceDockerComposeWriter(workspace_name=self.workspace_name, workspace_path=self.workspace_directory_manager.workspace_path, console=self.console, pgadmin_manager=self.pgadmin_manager)
         self.file_manager = FileManager()

--- a/blitzkrieg/workspace_manager.py
+++ b/blitzkrieg/workspace_manager.py
@@ -155,6 +155,12 @@ class WorkspaceManager:
             func=self.workspace_directory_manager.start_workspace_container
         )
 
+        self.console.add_action(
+            phase=workspace_container_initialization,
+            name="Saving workspace details to workspace database",
+            func=self.save_workspace_details()
+        )
+
         self.console.run_workflow(blitzkrieg_initialization_process)
 
     def teardown_workspace(self):
@@ -199,6 +205,9 @@ class WorkspaceManager:
         )
 
         self.console.run_workflow(teardown_workspace_process)
+
+    def save_workspace_details(self):
+        self.workspace_db_manager.save_workspace_details()
 
     def store_credentials(self):
         try:

--- a/blitzkrieg/workspace_manager.py
+++ b/blitzkrieg/workspace_manager.py
@@ -158,7 +158,7 @@ class WorkspaceManager:
         self.console.add_action(
             phase=workspace_container_initialization,
             name="Saving workspace details to workspace database",
-            func=self.save_workspace_details()
+            func=self.save_workspace_details
         )
 
         self.console.run_workflow(blitzkrieg_initialization_process)
@@ -166,6 +166,11 @@ class WorkspaceManager:
     def teardown_workspace(self):
         teardown_workspace_process = self.console.create_workflow("Teardown Workspace")
         workspace_teardown_group = self.console.create_phase(teardown_workspace_process, "Workspace Teardown")
+        # self.console.add_action(
+        #     phase=workspace_teardown_group,
+        #     name="Removing workspace details from database",
+        #     func=self.workspace_db_manager.remove_workspace_details
+        # )
         self.console.add_action(
             phase=workspace_teardown_group,
             name="Removing Workspace Postgres Database...",

--- a/migrations/README
+++ b/migrations/README
@@ -1,0 +1,1 @@
+Generic single-database configuration.


### PR DESCRIPTION
# Overview 
This PR adds functionality to the end of the ```blitz init <workspace_name> <is_reverse>``` flow to save workspace details to the workspace db to be accessed later on. 

## Changes Made 
- [x] adds workspace model
- [x] adds ```save_workspace_details``` functions to ```WorkspaceDBManager``` and ```WorkspaceManager``` classes
- [x] tests the addition of a row in the workspace table, after workapace creation
- [x] saves environment variables (attached is an image of all the environment variables that are now being tracked with this flow
![pr-image-feature-blitz-init-workspace-save-workspace-details](https://github.com/user-attachments/assets/27b298e4-23f0-410a-ba7c-a7d64f7e53ee)
- [x] saves workspace row with the following columns: 
![pr-image-feature-blitz-init-workspace-save-workspace-details-workspace-row](https://github.com/user-attachments/assets/00890951-0945-47f7-9e59-e1d62733c41c)


## Ancillary Changes
- [x] adds strong typing in the initalization of classes, when necessary