### PR TITLE
Fix/refactor command not using env vars for pypi api key

### DIFF
--- a/blitzkrieg/blitz_env_manager.py
+++ b/blitzkrieg/blitz_env_manager.py
@@ -3,7 +3,7 @@ from blitzkrieg.ui_management.console_instance import console
 from blitzkrieg.ui_management.ConsoleInterface import ConsoleInterface, FileManager
 
 class BlitzEnvManager:
-    def __init__(self, workspace_name: str):
+    def __init__(self, workspace_name: str = None):
         self.console = console
         self.workspace_name = workspace_name
         self.file_name = '.blitz.env'

--- a/blitzkrieg/cli/main.py
+++ b/blitzkrieg/cli/main.py
@@ -66,6 +66,8 @@ def setup_test():
 @click.option('--version', prompt='New version number', help='The new version number for the release')
 def release(version):
     """Set up Poetry and release a new version of Blitzkrieg to PyPI"""
+    blitz_env_manager = BlitzEnvManager()
+
     try:
         # Validate the version number
         packaging_version.parse(version)
@@ -97,9 +99,9 @@ def release(version):
 
         # Check for PyPI credentials
         pypi_username = "__token__"
-        pypi_api_key = "pypi key"
-        if not pypi_username or not pypi_api_key:
-            click.echo("PYPI_USERNAME or PYPI_API_KEY environment variable is not set. Please set both and try again.")
+        pypi_api_key = blitz_env_manager.get_env_var_value_from_global_env_file('PYPI_API_KEY')
+        if not pypi_api_key:
+            click.echo("PYPI_API_KEY is not set in the global .blitz.env file. Please set it and try again.")
             return
 
         # Publish to PyPI
@@ -119,6 +121,7 @@ def release(version):
         click.echo(f"An error occurred during the release process: {str(e)}")
     except Exception as e:
         click.echo(f"An unexpected error occurred: {str(e)}")
+
 if __name__ == "__main__":
     click.echo("Starting the application...")
     main()


### PR DESCRIPTION
# Fix: Refactor release command to use environment variables for PyPI API key

## Overview
This pull request addresses an issue where the release command was not utilizing environment variables for the PyPI API key. It also makes the `workspace_name` parameter optional in the `BlitzEnvManager` class, allowing for more flexible usage.

## Changes

### 1. BlitzEnvManager (`blitzkrieg/blitz_env_manager.py`)

- Modified the `__init__` method to accept an optional `workspace_name` parameter:
  ```python
  def __init__(self, workspace_name: str = None):
  ```
  This change allows the `BlitzEnvManager` to be instantiated without a specific workspace, which is useful for global operations like releasing.

### 2. CLI Main (`blitzkrieg/cli/main.py`)

- Updated the `release` command to use `BlitzEnvManager` for retrieving the PyPI API key:
  ```python
  blitz_env_manager = BlitzEnvManager()
  pypi_api_key = blitz_env_manager.get_env_var_value_from_global_env_file('PYPI_API_KEY')
  ```
- Modified the error message to specifically mention the PYPI_API_KEY:
  ```python
  click.echo("PYPI_API_KEY is not set in the global .blitz.env file. Please set it and try again.")
  ```
- Removed the check for `pypi_username` as it's hardcoded to "__token__".

## Why This Change is Necessary

1. **Security**: Using environment variables for sensitive information like API keys is a best practice.
2. **Flexibility**: Making `workspace_name` optional in `BlitzEnvManager` allows for more versatile use of the class.
3. **Consistency**: This change ensures that all sensitive information is handled in a uniform manner across the application.

## How This Has Been Tested

- Verified that the release command successfully retrieves the PyPI API key from the global `.blitz.env` file.
- Tested the `BlitzEnvManager` with and without a workspace name to ensure it functions correctly in both scenarios.

## Potential Risks

- Users who haven't set up their PYPI_API_KEY in the global `.blitz.env` file will need to do so before using the release command.

## TODO

- [ ] Update documentation to reflect the new way of handling the PyPI API key.
- [ ] Consider adding a command to easily set/update the PYPI_API_KEY in the global `.blitz.env` file.
